### PR TITLE
Added snippet for alter default privileges

### DIFF
--- a/snippets/table_default_priv.sql
+++ b/snippets/table_default_priv.sql
@@ -1,0 +1,28 @@
+select CONCAT('ALTER DEFAULT PRIVILEGES FOR USER "', rolname, 
+   '" IN SCHEMA "',nspname::text,'" GRANT ', perm_string[3]::text, ' ON TABLES TO "', rolname, '"') AS "GRANTS"
+from (
+select nspname,
+        object_type,
+(string_to_array(rtrim(ltrim(aclexplode(nspacl)::text,'('),')'),',')) as perm_string
+from
+ (select nspname,
+  'schema' as object_type,
+  nspacl from pg_namespace
+   where nspname not like 'pg_%' and nspname not in ('public', 'information_schema')
+ union
+ select nspname,
+  case(defaclobjtype)
+     when 'S' then 'sequence'
+      when 'r' then 'table'
+      when 'm' then 'mview'
+      when 'v' then 'view'
+      else 'other'
+      end,
+  d.defaclacl from pg_default_acl d
+    join pg_namespace s on s.oid=defaclnamespace
+    where nspname not like 'pg_%' and nspname not in ('public', 'information_schema')
+
+)s
+) b
+join pg_roles r on r.oid=b.perm_string[2]::oid
+where rolname = '{user}'

--- a/snippets/tests/test_table_default_priv.sh
+++ b/snippets/tests/test_table_default_priv.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo 'ALTER DEFAULT PRIVILEGES FOR USER "test3user" IN SCHEMA "test3schema" REVOKE SELECT, INSERT ON TABLES FROM "test3user";' | ./get_root_cli.sh
+echo 'DROP USER test3user;' | ./get_root_cli.sh
+echo 'DROP SCHEMA test3schema;' | ./get_root_cli.sh
+echo 'CREATE USER test3user;' | ./get_root_cli.sh
+echo 'CREATE SCHEMA test3schema;' | ./get_root_cli.sh
+echo 'ALTER DEFAULT PRIVILEGES FOR USER "test3user" IN SCHEMA "test3schema" GRANT SELECT, INSERT ON TABLES TO "test3user";' | ./get_root_cli.sh
+resSelect=`(cat ../table_default_priv.sql ; echo ";") | sed 's/{user}/test3user/' |(DBUSER=postgres ./get_user_cli.sh|grep SELECT)`
+resInsert=`(cat ../table_default_priv.sql ; echo ";") | sed 's/{user}/test3user/' |(DBUSER=postgres ./get_user_cli.sh|grep INSERT)`
+if [ ! "$(echo -n $resSelect)" = 'ALTER DEFAULT PRIVILEGES FOR USER "test3user" IN SCHEMA "test3schema" GRANT SELECT ON TABLES TO "test3user"' ]; then
+  echo "SELECT is missing: $resSelect"
+  exit 1
+fi
+
+if [ ! "$(echo -n $resInsert)" = 'ALTER DEFAULT PRIVILEGES FOR USER "test3user" IN SCHEMA "test3schema" GRANT INSERT ON TABLES TO "test3user"' ]; then
+  echo "INSERT is missing: $resSelect"
+  exit 1
+fi

--- a/snippets/tests/test_table_default_priv.sh
+++ b/snippets/tests/test_table_default_priv.sh
@@ -14,6 +14,6 @@ if [ ! "$(echo -n $resSelect)" = 'ALTER DEFAULT PRIVILEGES FOR USER "test3user" 
 fi
 
 if [ ! "$(echo -n $resInsert)" = 'ALTER DEFAULT PRIVILEGES FOR USER "test3user" IN SCHEMA "test3schema" GRANT INSERT ON TABLES TO "test3user"' ]; then
-  echo "INSERT is missing: $resSelect"
+  echo "INSERT is missing: $resInsert"
   exit 1
 fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a SQL query in `table_default_priv.sql` to retrieve and set default privileges for a specific user in a PostgreSQL database. This enhances the security by ensuring appropriate user permissions.
- Test: Introduced a bash script in `test_table_default_priv.sh` to validate the correct setting of default privileges for a new user in a new schema. This improves the reliability of the system by adding automated checks for user privileges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->